### PR TITLE
Fix Broken Links on Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Guides are very easy to understand tutorials.
 
 You'll want to read about [forking](https://help.github.com/articles/fork-a-repo)
 and then make your own fork of
-[=>railsbridge-nyc/docs](https://github.com/=>railsbridge-nyc/docs).  Once
+[=>railsbridge-nyc/docs](https://github.com/railsbridge-nyc/docs).  Once
 you've done so, you can clone it and get started by reading up on
 [what to do when submitting a pull request](#when-submitting-a-pull-request),
 read up on [pull requests](https://help.github.com/articles/using-pull-requests)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The RailsBridge Documentation Project
 
 [![Build
-Status](https://travis-ci.org/=>railsbridge-nyc/docs.png)](https://travis-ci.org/=>railsbridge-nyc/docs)
+Status](https://travis-ci.org/=>railsbridge-nyc/docs.png)](https://travis-ci.org/railsbridge-nyc/docs)
 
 ## Overview
 

--- a/lib/doc_page.rb
+++ b/lib/doc_page.rb
@@ -116,14 +116,14 @@ class DocPage < Html5Page
       p "RailsBridge Docs is maintained by RailsBridge volunteers."
       p do
         text "If you find something that could be improved, please make a "
-        a "pull request ", href: "https://github.com/=>railsbridge-nyc/docs"
+        a "pull request ", href: "https://github.com/railsbridge-nyc/docs"
         text "or "
-        a "drop us a note ", href: "https://github.com/=>railsbridge-nyc/docs/issues/new"
+        a "drop us a note ", href: "https://github.com/railsbridge-nyc/docs/issues/new"
         text "via GitHub Issues (no technical knowledge required)."
       end
       p do
         text "Source: "
-        url "https://github.com/=>railsbridge-nyc/docs"
+        url "https://github.com/railsbridge-nyc/docs"
       end
     }
   end

--- a/sites/en/docs/docs.step
+++ b/sites/en/docs/docs.step
@@ -1,5 +1,5 @@
 message <<MARKDOWN
-This site is maintained by RailsBridge volunteers. If you find something that could be improved, please make a [pull request](https://github.com/=>railsbridge-nyc/docs) or [drop us a note](https://github.com/=>railsbridge-nyc/docs/issues/new) via GitHub Issues (no technical knowledge required).
+This site is maintained by RailsBridge volunteers. If you find something that could be improved, please make a [pull request](https://github.com/railsbridge-nyc/docs) or [drop us a note](https://github.com/railsbridge-nyc/docs/issues/new) via GitHub Issues (no technical knowledge required).
 MARKDOWN
 
 h1 'Setup'
@@ -71,13 +71,13 @@ If you're not doing those two things, you can totally still use the site, we jus
 ### I want to help, but I don't know how.
 
 First, [make a GitHub account](https://github.com/). Then,
-[create an issue](https://github.com/=>railsbridge-nyc/docs/issues) with the
+[create an issue](https://github.com/railsbridge-nyc/docs/issues) with the
 idea you have. We'll help you turn it into reality (assuming it's in line with
 our lofty goals :D).
 
 Don't know what you could work on? Browse the
-[issues list](https://github.com/=>railsbridge-nyc/docs/issues) and the
-[To Do list](https://github.com/=>railsbridge-nyc/docs/wiki/RailsBridge-To-Do-List).
+[issues list](https://github.com/railsbridge-nyc/docs/issues) and the
+[To Do list](https://github.com/railsbridge-nyc/docs/wiki/RailsBridge-To-Do-List).
 Those have lots of ideas.
 
 


### PR DESCRIPTION
Several links on the docs page are incorrectly linking to Github.  A rocket operator is being included in the href, and thus leads to a 404 page.

![](https://www.evernote.com/l/AfaG7apLWgZDZIGte-S0lwHc3jkiIxaj44kB/image.png)
